### PR TITLE
Potential fix for code scanning alert no. 5: Clear-text logging of sensitive information

### DIFF
--- a/birthday/birthday.py
+++ b/birthday/birthday.py
@@ -379,7 +379,7 @@ class Birthday(commands.Cog):
             if birthday_channel_id:
                 channel = self.bot.get_channel(birthday_channel_id)
                 if not channel:  # If the set channel doesn't exist anymore
-                    logger.warning(f"Birthday channel {birthday_channel_id} not found in guild {ctx.guild.id}")
+                    logger.warning("Birthday channel not found in the guild")
                     channel = ctx.channel
             else:
                 channel = ctx.channel


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/Pac-cogs/security/code-scanning/5](https://github.com/pacnpal/Pac-cogs/security/code-scanning/5)

To fix the problem, we should avoid logging sensitive information such as `birthday_channel_id` and `ctx.guild.id` directly. Instead, we can log a more generic message that does not include these details. This way, we maintain the functionality of logging warnings without exposing sensitive data.

We will modify the log message on line 382 to remove the sensitive information. Specifically, we will replace the message with a more generic one that indicates a problem without revealing specific IDs.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
