### PR TITLE
Potential fix for code scanning alert no. 2: Clear-text logging of sensitive information

### DIFF
--- a/birthday/birthday.py
+++ b/birthday/birthday.py
@@ -63,7 +63,7 @@ async def birthday_context_menu(interaction: discord.Interaction, member: discor
         if birthday_channel_id:
             channel = interaction.client.get_channel(birthday_channel_id)
             if not channel:
-                logger.warning(f"Birthday channel {birthday_channel_id} not found in guild {interaction.guild.id}")
+                logger.warning("Birthday channel not found in the guild")
                 channel = interaction.channel
         else:
             channel = interaction.channel


### PR DESCRIPTION
Potential fix for [https://github.com/pacnpal/Pac-cogs/security/code-scanning/2](https://github.com/pacnpal/Pac-cogs/security/code-scanning/2)

To fix the problem, we should avoid logging sensitive information directly. Instead, we can log a more generic message that does not include specific IDs. This way, we still get useful log information without exposing sensitive data.

- Replace the log message on line 66 with a more generic message that does not include `birthday_channel_id` or `interaction.guild.id`.
- Ensure that the new log message still provides enough context to understand the issue without revealing sensitive information.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
